### PR TITLE
修复 MT-Syntax 中不规范的括号使用

### DIFF
--- a/mtsx/builtin/MT-Syntax.mtsx
+++ b/mtsx/builtin/MT-Syntax.mtsx
@@ -152,13 +152,13 @@
 				childrenStyle: "regex"
 				// matchEndFirst: true
 				mustMatchEnd: true
-				contains: {
+				contains: [
 					{match: "\\/" 0: "strEscape"}
 					{include: "escapes_1"}
 					{include: "charset_1"}
 					{include: "regex"}
 					// {match: /(?<!\\)\//} => FAIL
-				}
+				]
 			}
 			{
 				start: {match: /(?<=(?:match:|\+)\s?)"/}


### PR DESCRIPTION
这个问题已经在上游修复了, 补丁一下

顺便一提, 我制作了一个适用于 mtsx 的语言服务器 [mtsx-ls](https://github.com/A4-Tacks/mtsx-ls),
支持 VSCode, 或是 vim 等可以自主加载语言服务器的编辑器, 对于手动编写 mtsx 来说非常方便
